### PR TITLE
bump to v1.14

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,10 +41,10 @@ parts:
   scrcpy-server:
     plugin: nil
     override-pull:
-      wget https://github.com/Genymobile/scrcpy/releases/download/v1.13/scrcpy-server-v1.13
+      wget https://github.com/Genymobile/scrcpy/releases/download/v1.14/scrcpy-server-v1.14
     override-build: |
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/local/share/scrcpy/
-      cp scrcpy-server-v1.13 $SNAPCRAFT_PART_INSTALL/usr/local/share/scrcpy/scrcpy-server
+      cp scrcpy-server-v1.14 $SNAPCRAFT_PART_INSTALL/usr/local/share/scrcpy/scrcpy-server
 
   scrcpy:
     source: https://github.com/Genymobile/scrcpy.git


### PR DESCRIPTION
Hi @sisco311, I just adapted the changes you've made in commit 717e15b3189b181b1bbcf6028efc799335eaab45 to the [freshly released v1.14](https://github.com/Genymobile/scrcpy/releases).

If it is not correct, I would be glad to learn more about how a new version is born and to collaborate in the process :)

BTW thank you for the snap, it was really helpful to me!