### PR TITLE
git: avoid tracking built snap packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Avoid tracking built snaps
+*.snap


### PR DESCRIPTION
Avoid listing built snap packages as content that can be tracked in the `git status` output.